### PR TITLE
fail the build if buildpack-run.sh fails

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,5 +25,5 @@ set -o pipefail
 
 cd "$BUILD_DIR"
 echo "Sourcing buildpack-run.sh" | sed 's/^/-----> /'
-source ./buildpack-run.sh        | sed 's/^/       /'
+source ./buildpack-run.sh 2>&1   | sed 's/^/       /'
 echo

--- a/bin/compile
+++ b/bin/compile
@@ -16,9 +16,14 @@
 # Daniel Weibel <daniel.weibel@unifr.ch> March 2015
 #------------------------------------------------------------------------------#
 
-set -e
+BUILD_DIR=$1
+CACHE_DIR=$2
+ENV_DIR=$3
 
-cd "$1"
+set -e
+set -o pipefail
+
+cd "$BUILD_DIR"
 echo "Sourcing buildpack-run.sh" | sed 's/^/-----> /'
 source ./buildpack-run.sh        | sed 's/^/       /'
 echo


### PR DESCRIPTION
if `buildpack-run.sh` has a non-zero exit code, then something went wrong
also set the BUILD_DIR, CACHE_DIR, and ENV_DIR variables so that buildpack-run.sh can easily access it
