### PR TITLE
Add load Heroku runtime environment if BUILDPACK_HEROKU_ENV set

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Notes:
 
 - `./script.sh` is a user-provided shell script
 - `ls -l` refers to the native `ls` command on the build dyno
-- `bin/myexec` is a user-provided binary 
+- `bin/myexec` is a user-provided binary
 
 ### Default value
 
@@ -66,6 +66,13 @@ The following special environment variables are available to your commands durin
 - `ENV_DIR`: directory containing the values of all config variables in files
 
 `BUILD_DIR` corresponds to the working directory during the execution of the buildpack.
+
+## Heroku config environment variables
+If you wish your commands to have access to the environment variables set in your Heroku config, then ensure the `BUILDPACK_HEROKU_ENV` env config exists.
+
+This will cause all env config values to be loaded into the runtime environment for your commands, before they execute.
+
+There are some minor exceptions to avoid common issues. Check `bin/compile load_env_dir()`
 
 ## License
 

--- a/bin/compile
+++ b/bin/compile
@@ -32,13 +32,32 @@ a() { sed 's/^/-----> /'; }
 I() { sed "s/^/$(printf '\033')[31m       /;s/$/$(printf '\033')[0m/"; }
 A() { sed "s/^/$(printf '\033')[31m-----> /;s/$/$(printf '\033')[0m/"; }
 
-
 # These environment variables can be accessed from the user-supplied commands
 export BUILD_DIR=$1
 export CACHE_DIR=$2
 export ENV_DIR=$3
 
 cd "$BUILD_DIR"
+
+# Load Heroku config environment to runtime environment
+# https://devcenter.heroku.com/articles/buildpack-api#bin-compile
+load_env_dir() {
+  acceptlist_regex=${2:-''}
+  denylist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
+  if [ -d "$ENV_DIR" ]; then
+    for e in $(ls $ENV_DIR); do
+      echo "$e" | grep -E "$acceptlist_regex" | grep -qvE "$denylist_regex" &&
+      export "$e=$(cat $ENV_DIR/$e)"
+      :
+    done
+  fi
+}
+
+# Load Heroku config to runtime environment if BUILDPACK_HEROKU_ENV exists
+if [[ -f "$ENV_DIR/BUILDPACK_HEROKU_ENV" ]]; then
+  load_env_dir
+  echo "Loading Heroku config to runtime" | A
+fi
 
 # Extract commands from BUILDPACK_RUN config variable
 if [[ -f "$ENV_DIR/BUILDPACK_RUN" ]]; then


### PR DESCRIPTION
Adds the ability to load the Heroku environment config variables into the runtime execution of the commands for the buildpack

Tested working on my production app

Solves issue: https://github.com/weibeld/heroku-buildpack-run/issues/10